### PR TITLE
Potential fix for code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'https://api.xn--bgtt50a8xt.cn',
+        target: 'https://api.xn--bgtt50a8xt.top',
         changeOrigin: true,
         secure: true,
         rewrite: (path) => path.replace(/^\/api/, '')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
         target: 'https://api.xn--bgtt50a8xt.cn',
         changeOrigin: true,
         secure: true,
-        rewrite: (path) => path.replace(/^\/api/, '/api')
+        rewrite: (path) => path.replace(/^\/api/, '')
       }
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Luo202044/cl/security/code-scanning/1](https://github.com/Luo202044/cl/security/code-scanning/1)

To fix this class of issue, ensure the replacement string is meaningfully different from the matched substring and matches the intended proxy behavior. For Vite proxying from `/api` to a backend root, the common fix is to strip the `/api` prefix.

In `vite.config.ts`, update the `rewrite` callback on line 14 from replacing `^/api` with `'/api'` to replacing it with `''` (empty string). This preserves existing functionality intention (proxying API calls) while making rewrite effective and resolving the CodeQL finding. No imports, extra methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
