### PR TITLE
Potential fix for code scanning alert no. 9: Clear text storage of sensitive information

### DIFF
--- a/src/views/Admin/FeedbackAdmin.vue
+++ b/src/views/Admin/FeedbackAdmin.vue
@@ -257,7 +257,7 @@ const login = async () => {
     if (result.code === 200 && result.data !== undefined) {
       token.value = testToken;
       isAuthenticated.value = true;
-      sessionStorage.setItem('feedback_admin_token', token.value);
+      // 不在浏览器存储中持久化敏感 Token，仅保留会话内存态
       sessionStorage.setItem('feedback_admin_auth', 'true');
       await loadFeedbacks(1);
     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Luo202044/cl/security/code-scanning/9](https://github.com/Luo202044/cl/security/code-scanning/9)

通用修复思路：避免在客户端持久化敏感凭据（尤其是 `sessionStorage/localStorage/cookie` 明文）。在不改变现有功能太多的前提下，最佳做法是仅保留会话内存态（Vue `ref`），并用“是否已登录”的非敏感标记来维持 UI 状态；页面刷新后要求重新登录。

针对当前文件 `src/views/Admin/FeedbackAdmin.vue`，最优单点修复是：
1. 在登录成功处删除 `sessionStorage.setItem('feedback_admin_token', token.value)`；
2. 保留或新增仅非敏感状态的存储（如 `feedback_admin_auth`）；
3. 在组件初始化/恢复会话逻辑中，不再从 `sessionStorage` 读取 token，也不要基于存储中的 token 自动发请求；只恢复布尔 UI 状态，或直接要求重新登录；
4. 登出时确保清理 `feedback_admin_auth`（和遗留 `feedback_admin_token`，用于兼容清理）。

这样可以消除 CodeQL 指向的明文敏感数据存储，同时不影响“本次打开页面期间”的管理功能（token 仍在内存中用于请求）。


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
